### PR TITLE
Cleanup leon

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,2 @@
 UnityAds filter=lfs diff=lfs merge=lfs -text
-*.tgz filter=lfs diff=lfs merge=lfs -text
-*.png filter=lfs diff=lfs merge=lfs -text
-*.7z filter=lfs diff=lfs merge=lfs -text
-*.pdb filter=lfs diff=lfs merge=lfs -text
 ArtifactDB filter=lfs diff=lfs merge=lfs -text
-*.tga filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
- Removed lfs tags
- Pulled missing lfs content (tgz files) to resolve missing package error for SteamVR